### PR TITLE
세션 기반 로그인/로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/imjang/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/imjang/domain/auth/controller/AuthController.java
@@ -1,13 +1,17 @@
 package com.imjang.domain.auth.controller;
 
 import com.imjang.domain.auth.dto.request.EmailVerificationRequest;
+import com.imjang.domain.auth.dto.request.LoginRequest;
 import com.imjang.domain.auth.dto.request.ResendVerificationRequest;
 import com.imjang.domain.auth.dto.request.SignUpRequest;
+import com.imjang.domain.auth.dto.response.LoginResponse;
 import com.imjang.domain.auth.dto.response.SignUpResponse;
 import com.imjang.domain.auth.dto.response.VerificationResponse;
 import com.imjang.domain.auth.service.AuthService;
+import com.imjang.domain.auth.service.LoginService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
   private final AuthService authService;
+  private final LoginService loginService;
 
   /**
    * 회원가입
@@ -58,6 +63,30 @@ public class AuthController {
   @PostMapping("/verifications:resend")
   public ResponseEntity<Void> resendVerification(@Valid @RequestBody ResendVerificationRequest request) {
     authService.resendVerification(request);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * 로그인
+   * POST /api/v1/auth/login
+   */
+  @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+  @PostMapping("/login")
+  public ResponseEntity<LoginResponse> login(
+          @Valid @RequestBody LoginRequest request,
+          HttpSession session) {
+    LoginResponse response = loginService.login(request, session);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 로그아웃
+   * POST /api/v1/auth/logout
+   */
+  @Operation(summary = "로그아웃", description = "현재 세션을 종료합니다.")
+  @PostMapping("/logout")
+  public ResponseEntity<Void> logout(HttpSession session) {
+    loginService.logout(session);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/imjang/domain/auth/dto/UserSession.java
+++ b/src/main/java/com/imjang/domain/auth/dto/UserSession.java
@@ -1,0 +1,23 @@
+package com.imjang.domain.auth.dto;
+
+import com.imjang.domain.auth.entity.UserRole;
+import java.io.Serializable;
+
+/**
+ * 세션 저장될 사용자 정보
+ * TODO: Serializable 구현 필요
+ */
+public record UserSession(
+        Long userId,
+        String email,
+        UserRole role
+) implements Serializable {
+
+  public static UserSession of(Long userId, String email, UserRole role) {
+    return new UserSession(userId, email, role);
+  }
+
+  public boolean isAdmin() {
+    return role == UserRole.ADMIN;
+  }
+}

--- a/src/main/java/com/imjang/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/imjang/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,22 @@
+package com.imjang.domain.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Schema(description = "로그인 요청 DTO")
+public record LoginRequest(
+        @Schema(description = "이메일", example = "user@example.com")
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @Schema(description = "비밀번호", example = "password")
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        String password
+) {
+
+}

--- a/src/main/java/com/imjang/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/imjang/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.imjang.domain.auth.dto.response;
+
+import com.imjang.domain.auth.entity.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 로그인 응답 DTO
+ */
+@Schema(description = "로그인 응답")
+public record LoginResponse(
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "이메일", example = "user@example.com")
+        String email,
+
+        @Schema(description = "사용자 권한", example = "USER")
+        UserRole role,
+
+        @Schema(description = "메시지", example = "로그인 성공")
+        String message
+) {
+
+  public static LoginResponse of(Long userId, String email, UserRole role) {
+    return new LoginResponse(userId, email, role, "로그인 성공");
+  }
+}

--- a/src/main/java/com/imjang/domain/auth/service/LoginService.java
+++ b/src/main/java/com/imjang/domain/auth/service/LoginService.java
@@ -1,0 +1,80 @@
+package com.imjang.domain.auth.service;
+
+import com.imjang.domain.auth.dto.UserSession;
+import com.imjang.domain.auth.dto.request.LoginRequest;
+import com.imjang.domain.auth.dto.response.LoginResponse;
+import com.imjang.domain.auth.entity.User;
+import com.imjang.domain.auth.entity.UserStatus;
+import com.imjang.domain.auth.repository.UserRepository;
+import com.imjang.global.exception.CustomException;
+import com.imjang.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+  public static final String SESSION_KEY = "USER_SESSION";
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  /**
+   * 로그인 처리
+   *
+   * @param request
+   *         로그인 요청 DTO
+   */
+  public LoginResponse login(LoginRequest request, HttpSession session) {
+    User user = userRepository.findByEmail(request.email())
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+      throw new CustomException(ErrorCode.INVALID_PASSWORD);
+    }
+
+    if (user.getStatus() != UserStatus.ACTIVE) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED, "이메일 인증이 필요합니다.");
+    }
+
+    UserSession userSession = UserSession.of(
+            user.getId(),
+            user.getEmail(),
+            user.getRole()
+    );
+
+    session.setAttribute(SESSION_KEY, userSession);
+
+    log.info("유저가 로그인했습니다. email: {}", user.getEmail());
+
+    return LoginResponse.of(user.getId(), user.getEmail(), user.getRole());
+  }
+
+  /**
+   * 로그아웃 처리
+   */
+  public void logout(HttpSession session) {
+    if (session != null) {
+      UserSession userSession = (UserSession) session.getAttribute(SESSION_KEY);
+      if (userSession != null) {
+        log.info("User logged out: {}", userSession.email());
+      }
+      session.invalidate();
+    }
+  }
+
+  /**
+   * 현재 로그인한 사용자 정보 조회
+   */
+  public UserSession getCurrentUser(HttpSession session) {
+    if (session == null) {
+      return null;
+    }
+    return (UserSession) session.getAttribute(SESSION_KEY);
+  }
+}

--- a/src/main/java/com/imjang/global/annotation/LoginRequired.java
+++ b/src/main/java/com/imjang/global/annotation/LoginRequired.java
@@ -1,0 +1,12 @@
+package com.imjang.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginRequired {
+
+}

--- a/src/main/java/com/imjang/global/config/WebConfig.java
+++ b/src/main/java/com/imjang/global/config/WebConfig.java
@@ -1,0 +1,28 @@
+package com.imjang.global.config;
+
+import com.imjang.global.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * 웹 관련 설정 클래스
+ * Spring MVC 설정을 위한 클래스입니다.
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+  private final AuthInterceptor authInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(authInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns(
+                    "/api/v1/auth/**",
+                    "/api/health"
+            );
+  }
+}

--- a/src/main/java/com/imjang/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/imjang/global/interceptor/AuthInterceptor.java
@@ -1,0 +1,54 @@
+package com.imjang.global.interceptor;
+
+import com.imjang.domain.auth.dto.UserSession;
+import com.imjang.domain.auth.service.LoginService;
+import com.imjang.global.annotation.LoginRequired;
+import com.imjang.global.exception.CustomException;
+import com.imjang.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * 인증 인터셉터
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthInterceptor implements HandlerInterceptor {
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    if (!(handler instanceof HandlerMethod)) {
+      return true;
+    }
+    HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+    LoginRequired loginRequired = handlerMethod.getMethodAnnotation(LoginRequired.class);
+    if (loginRequired == null) {
+      loginRequired = handlerMethod.getBeanType().getAnnotation(LoginRequired.class);
+    }
+    if (loginRequired == null) {
+      // 로그인 필요하지 않은 경우
+      return true;
+    }
+    HttpSession session = request.getSession(false);
+    if (session == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+
+    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
+    if (userSession == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+
+    log.debug("🔓인증된 사용자 정보: {}", userSession.email());
+
+    return true;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,6 +88,15 @@ server:
     include-stacktrace: on_param  # ?trace=true 파라미터로 확인 가능
     include-exception: false
 
+  servlet:
+    session:
+      timeout: 30m
+      cookie:
+        http-only: true
+        secure: false
+        name: JSESSIONID  # 기본값 사용
+        path: /
+
 # 로깅 설정
 logging:
   level:


### PR DESCRIPTION
## 📌 변경 사항 개요

- 세션 기반 인증 처리 프로세스 구현
- 로그인 성공 시 사용자 정보를 세션에 저장하고 로그아웃 시 세션 무효화 처리
- 인증이 필요한 API 접근 시 세션 검증하는 인터셉터 및 어노테이션 추가

## 🛠 주요 변경 사항

1. [기능] 로그인/로그아웃 API 추가 (`AuthController`에 `/login`, `/logout` 엔드포인트 추가)
2. [기능] 세션 기반 인증 서비스 구현 (`LoginService` 클래스 생성)
3. [기능] 로그인 인증 체크를 위한 인터셉터 추가 (`AuthInterceptor`, `@LoginRequired` 애노테이션)
4. [설정] 세션 타임아웃 및 쿠키 보안 설정 추가 (`application.yml`)
5. [DTO] 로그인 관련 DTO 생성 (`LoginRequest`, `LoginResponse`, `UserSession`)

## 📋 작업 상세 내용

### 인증 프로세스
- 로그인 시 이메일/비밀번호 검증 후 세션에 사용자 정보(`UserSession`) 저장
- 세션 키: `USER_SESSION`
- 로그아웃 시 세션 무효화 처리

### 보안 설정
- 세션 타임아웃: 30분
- HttpOnly 쿠키 사용 (XSS 공격 방지)
- 세션 쿠키명: JSESSIONID (기본값)

### 인터셉터 동작
- `/api/**` 경로에 대해 인증 검사
- `/api/v1/auth/**`, `/api/health` 경로는 제외
- `@LoginRequired` 애노테이션이 있는 컨트롤러/메서드만 인증 필요
