### PR TITLE
매물에 이미지 추가 기능 구현

### DIFF
--- a/src/main/java/com/imjang/domain/property/controller/PropertyImageController.java
+++ b/src/main/java/com/imjang/domain/property/controller/PropertyImageController.java
@@ -1,0 +1,56 @@
+package com.imjang.domain.property.controller;
+
+import com.imjang.domain.auth.dto.UserSession;
+import com.imjang.domain.auth.service.LoginService;
+import com.imjang.domain.property.dto.request.AddPropertyImagesRequest;
+import com.imjang.domain.property.dto.response.AddPropertyImagesResponse;
+import com.imjang.domain.property.service.PropertyService;
+import com.imjang.global.annotation.LoginRequired;
+import com.imjang.global.exception.CustomException;
+import com.imjang.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "PropertyImage", description = "매물 이미지 관리 API")
+@RestController
+@RequestMapping("/api/v1/properties")
+@RequiredArgsConstructor
+public class PropertyImageController {
+
+  private final PropertyService propertyService;
+
+  @Operation(summary = "매물 이미지 추가",
+          description = "기존 매물에 이미지를 추가합니다. 임시 이미지 ID 목록을 전달받아 매물 이미지로 변환합니다.")
+  @PostMapping("/{propertyId}/images")
+  @LoginRequired
+  public ResponseEntity<AddPropertyImagesResponse> addImagesToProperty(
+          @Parameter(description = "매물 ID", required = true, example = "1")
+          @PathVariable Long propertyId,
+          @Valid @RequestBody AddPropertyImagesRequest request,
+          HttpSession session) {
+
+    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
+    if (userSession == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+
+    AddPropertyImagesResponse response = propertyService.addImagesToProperty(
+            propertyId,
+            request.tempImageIds(),
+            userSession.userId()
+    );
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+}

--- a/src/main/java/com/imjang/domain/property/dto/request/AddPropertyImagesRequest.java
+++ b/src/main/java/com/imjang/domain/property/dto/request/AddPropertyImagesRequest.java
@@ -1,0 +1,16 @@
+package com.imjang.domain.property.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+@Schema(description = "매물 이미지 추가 요청")
+public record AddPropertyImagesRequest(
+        @Schema(description = "임시 이미지 ID 목록", example = "[1234, 5678, 9012]")
+        @NotNull(message = "이미지 ID 목록은 필수입니다")
+        @Size(min = 1, message = "최소 1개 이상의 이미지가 필요합니다")
+        List<Long> tempImageIds
+) {
+
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/AddPropertyImagesResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/AddPropertyImagesResponse.java
@@ -1,0 +1,15 @@
+package com.imjang.domain.property.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "매물 이미지 추가 응답")
+public record AddPropertyImagesResponse(
+        @Schema(description = "추가된 이미지 ID 목록", example = "[5678, 5679, 5680]")
+        List<Long> imageIds
+) {
+
+  public static AddPropertyImagesResponse of(List<Long> imageIds) {
+    return new AddPropertyImagesResponse(imageIds);
+  }
+}


### PR DESCRIPTION
## Sourcery 요약

보안 API 엔드포인트, 유효성 검사 및 영속성을 위한 서비스 로직, 이벤트 게시를 도입하여 기존 속성에 이미지를 추가하는 기능을 구현합니다.

새로운 기능:
- 임시 이미지를 속성에 첨부하기 위해 POST /api/v1/properties/{propertyId}/images 엔드포인트 추가
- 소유권 검증, 임시 이미지 변환, 표시 순서 할당, 이미지 저장 및 이벤트 게시를 위한 addImagesToProperty 서비스 메서드 구현
- 새로운 API를 위한 AddPropertyImagesRequest 및 AddPropertyImagesResponse DTO 도입

개선 사항:
- 시작 표시 순서로 PropertyImage 엔티티 생성을 중앙 집중화하기 위해 createPropertyImages 도우미 함수 추출
- 이미지 생성을 새로운 도우미 함수에 위임하도록 linkImagesToProperty 리팩토링

문서:
- 속성 이미지 관리 컨트롤러 및 DTO에 Swagger 어노테이션 추가

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement the ability to add images to an existing property by introducing a secured API endpoint, service logic for validation and persistence, and event publication.

New Features:
- Add POST /api/v1/properties/{propertyId}/images endpoint to attach temporary images to a property
- Implement addImagesToProperty service method to validate ownership, convert temp images, assign display orders, save images, and publish an event
- Introduce AddPropertyImagesRequest and AddPropertyImagesResponse DTOs for the new API

Enhancements:
- Extract createPropertyImages helper to centralize PropertyImage entity creation with a starting display order
- Refactor linkImagesToProperty to delegate image creation to the new helper

Documentation:
- Add Swagger annotations to the property image management controller and DTOs

</details>