### PR TITLE
최근 매물 목록 조회 API

### DIFF
--- a/src/main/java/com/imjang/domain/property/dto/response/PriceInfoResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/PriceInfoResponse.java
@@ -1,0 +1,17 @@
+package com.imjang.domain.property.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가격 정보")
+public record PriceInfoResponse(
+        @Schema(description = "보증금", example = "350000000")
+        Long deposit,
+
+        @Schema(description = "월세", example = "800000")
+        Long monthlyRent,
+
+        @Schema(description = "매매가", example = "850000000")
+        Long price
+) {
+
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/PropertySummaryResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/PropertySummaryResponse.java
@@ -1,0 +1,31 @@
+package com.imjang.domain.property.dto.response;
+
+import com.imjang.domain.property.entity.PropertyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "매물 요약 정보")
+public record PropertySummaryResponse(
+        @Schema(description = "매물 ID", example = "123")
+        Long id,
+
+        @Schema(description = "주소", example = "서울시 강남구 역삼동 123-45")
+        String address,
+
+        @Schema(description = "방문일시", example = "2024-12-19T10:00:00")
+        LocalDateTime visitedAt,
+
+        @Schema(description = "가격 유형", example = "JEONSE")
+        PropertyType priceType,
+
+        @Schema(description = "가격 정보")
+        PriceInfoResponse priceInfo,
+
+        @Schema(description = "평점", example = "4")
+        Integer rating,
+
+        @Schema(description = "썸네일 이미지 URL", example = "/temp-images/2024/12/19/thumb_abc123.jpg")
+        String thumbnailUrl
+) {
+
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/RecentPropertyResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/RecentPropertyResponse.java
@@ -1,0 +1,18 @@
+package com.imjang.domain.property.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "최근 매물 목록 응답")
+public record RecentPropertyResponse(
+        @Schema(description = "매물 목록")
+        List<PropertySummaryResponse> properties,
+
+        @Schema(description = "전체 매물 개수", example = "45")
+        long totalCount,
+
+        @Schema(description = "이번 달 기록한 매물 개수", example = "12")
+        long monthlyRecordCount
+) {
+
+}

--- a/src/main/java/com/imjang/domain/property/repository/PropertyImageRepository.java
+++ b/src/main/java/com/imjang/domain/property/repository/PropertyImageRepository.java
@@ -2,9 +2,16 @@ package com.imjang.domain.property.repository;
 
 import com.imjang.domain.property.entity.PropertyImage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PropertyImageRepository extends JpaRepository<PropertyImage, Long> {
 
   List<PropertyImage> findByPropertyIdOrderByDisplayOrder(Long propertyId);
+
+  // 썸네일 이미지 조회 (displayOrder = 0)
+  Optional<PropertyImage> findByPropertyIdAndDisplayOrder(Long propertyId, Integer displayOrder);
+
+  // 여러 매물의 썸네일 이미지 한번에 조회
+  List<PropertyImage> findByPropertyIdInAndDisplayOrder(List<Long> propertyIds, Integer displayOrder);
 }

--- a/src/main/java/com/imjang/domain/property/repository/PropertyRepository.java
+++ b/src/main/java/com/imjang/domain/property/repository/PropertyRepository.java
@@ -1,7 +1,10 @@
 package com.imjang.domain.property.repository;
 
 import com.imjang.domain.property.entity.Property;
+import java.time.LocalDateTime;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +14,14 @@ public interface PropertyRepository extends JpaRepository<Property, Long> {
   @Query("SELECT p FROM Property p LEFT JOIN FETCH p.environments WHERE p.id = :id")
   Optional<Property> findByIdWithEnvironments(@Param("id") Long id);
 
+  // 최근 매물 조회
+  Page<Property> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+  // 전체 매물 개수 조회
+  long countByUserIdAndDeletedAtIsNull(Long userId);
+
+  // 이번 달 매물 개수 조회
+  long countByUserIdAndDeletedAtIsNullAndCreatedAtBetween(Long userId,
+                                                          LocalDateTime startOfMonth,
+                                                          LocalDateTime endOfMonth);
 }


### PR DESCRIPTION
## 📌 변경 사항 개요

- 메인 화면에서 사용자의 최근 매물 목록을 페이징하여 조회할 수 있는 API를 구현했습니다.
- 예:
    - 최근 매물 목록 조회 API 엔드포인트 추가
    - 매물 요약 정보와 통계 데이터 반환

## 🛠 주요 변경 사항

1. [기능] 최근 매물 목록 조회 API 추가 (`GET /properties/recent`)
2. [기능] 매물 요약 정보 응답 DTO 구현 (`PropertySummaryResponse`, `RecentPropertyResponse`, `PriceInfoResponse`)
3. [수정] Repository 인터페이스 확장 - 페이징 조회, 월별 통계, 썸네일 일괄 조회 메서드 추가
4. [기능] 서비스 레이어에 최근 매물 조회 비즈니스 로직 구현

## 📋 작업 상세 내용

- 이 PR이 코드베이스에 어떤 영향을 미치는지 상세히 설명하세요.
- 데이터베이스 변경 여부, 새로운 의존성 추가 여부 등도 포함하세요.
    - 데이터베이스 변경:
        - 변경 사항 없음 (기존 테이블 활용)
    - 새로운 의존성:
        - 추가된 의존성 없음
    - API 스펙:
        - `GET /api/properties/recent?limit=3` - 최근 매물 목록 조회
        - 기본값 3개, 최소 1개, 최대 10개까지 조회 가능
        - 응답에는 매물 요약 정보, 전체 개수, 이번 달 기록 개수 포함
