### PR TITLE
지도 API

### DIFF
--- a/src/main/java/com/imjang/domain/property/controller/ImageController.java
+++ b/src/main/java/com/imjang/domain/property/controller/ImageController.java
@@ -1,15 +1,12 @@
 package com.imjang.domain.property.controller;
 
 import com.imjang.domain.auth.dto.UserSession;
-import com.imjang.domain.auth.service.LoginService;
 import com.imjang.domain.property.dto.response.ImageUploadResponse;
 import com.imjang.domain.property.service.ImageService;
 import com.imjang.global.annotation.LoginRequired;
-import com.imjang.global.exception.CustomException;
-import com.imjang.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -33,12 +30,9 @@ public class ImageController {
   @LoginRequired
   public ResponseEntity<ImageUploadResponse> uploadImage(
           @RequestPart("image") MultipartFile image,
-          HttpSession session) {
+          HttpServletRequest servletRequest) {
 
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
     ImageUploadResponse response = imageService.uploadImage(image, userSession.userId());
 
     return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/imjang/domain/property/controller/PropertyController.java
+++ b/src/main/java/com/imjang/domain/property/controller/PropertyController.java
@@ -1,7 +1,6 @@
 package com.imjang.domain.property.controller;
 
 import com.imjang.domain.auth.dto.UserSession;
-import com.imjang.domain.auth.service.LoginService;
 import com.imjang.domain.property.dto.request.CreatePropertyRequest;
 import com.imjang.domain.property.dto.request.PrefetchLocationRequest;
 import com.imjang.domain.property.dto.request.UpdatePropertyDetailRequest;
@@ -13,12 +12,10 @@ import com.imjang.domain.property.service.PropertyDetailService;
 import com.imjang.domain.property.service.PropertyService;
 import com.imjang.global.annotation.LoginRequired;
 import com.imjang.global.common.response.MessageResponse;
-import com.imjang.global.exception.CustomException;
-import com.imjang.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -51,12 +48,9 @@ public class PropertyController {
   @LoginRequired
   public ResponseEntity<MessageResponse> prefetchLocation(
           @Valid @RequestBody PrefetchLocationRequest request,
-          HttpSession session) {
+          HttpServletRequest servletRequest) {
 
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
 
     // 비동기로 위치 정보 수집 시작
     eventPublisher.publishEvent(new LocationPrefetchEvent(
@@ -76,12 +70,9 @@ public class PropertyController {
   @LoginRequired
   public ResponseEntity<MessageResponse> createProperty(
           @Valid @RequestBody CreatePropertyRequest request,
-          HttpSession session) {
+          HttpServletRequest servletRequest) {
 
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
     propertyService.createProperty(request, userSession.userId());
 
     return ResponseEntity.status(HttpStatus.CREATED)
@@ -95,12 +86,9 @@ public class PropertyController {
   public ResponseEntity<PropertyDetailResponse> getPropertyDetail(
           @Parameter(description = "매물 ID", required = true, example = "1")
           @PathVariable Long propertyId,
-          HttpSession session) {
+          HttpServletRequest servletRequest) {
 
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
 
     PropertyDetailResponse response = propertyDetailService.getPropertyDetail(propertyId, userSession.userId());
 
@@ -116,11 +104,8 @@ public class PropertyController {
           @Parameter(description = "매물 ID", required = true, example = "123")
           @PathVariable Long propertyId,
           @Valid @RequestBody UpdatePropertyDetailRequest request,
-          HttpSession session) {
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+          HttpServletRequest servletRequest) {
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
 
     UpdatePropertyDetailResponse response = propertyDetailService.updatePropertyDetail(
             propertyId,
@@ -141,11 +126,8 @@ public class PropertyController {
           @Min(value = 1, message = "최소 1개 이상")
           @Max(value = 10, message = "최대 10개까지 조회 가능")
           Integer limit,
-          HttpSession session) {
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+          HttpServletRequest servletRequest) {
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
 
     RecentPropertyResponse response = propertyService.getRecentProperties(userSession.userId(), limit);
 

--- a/src/main/java/com/imjang/domain/property/controller/PropertyImageController.java
+++ b/src/main/java/com/imjang/domain/property/controller/PropertyImageController.java
@@ -1,17 +1,14 @@
 package com.imjang.domain.property.controller;
 
 import com.imjang.domain.auth.dto.UserSession;
-import com.imjang.domain.auth.service.LoginService;
 import com.imjang.domain.property.dto.request.AddPropertyImagesRequest;
 import com.imjang.domain.property.dto.response.AddPropertyImagesResponse;
 import com.imjang.domain.property.service.PropertyService;
 import com.imjang.global.annotation.LoginRequired;
-import com.imjang.global.exception.CustomException;
-import com.imjang.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -38,12 +35,9 @@ public class PropertyImageController {
           @Parameter(description = "매물 ID", required = true, example = "1")
           @PathVariable Long propertyId,
           @Valid @RequestBody AddPropertyImagesRequest request,
-          HttpSession session) {
+          HttpServletRequest servletRequest) {
 
-    UserSession userSession = (UserSession) session.getAttribute(LoginService.SESSION_KEY);
-    if (userSession == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-    }
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
 
     AddPropertyImagesResponse response = propertyService.addImagesToProperty(
             propertyId,

--- a/src/main/java/com/imjang/domain/property/controller/PropertyMapController.java
+++ b/src/main/java/com/imjang/domain/property/controller/PropertyMapController.java
@@ -1,0 +1,61 @@
+package com.imjang.domain.property.controller;
+
+import com.imjang.domain.auth.dto.UserSession;
+import com.imjang.domain.property.dto.request.MapBoundsRequest;
+import com.imjang.domain.property.dto.response.MapMarkersResponse;
+import com.imjang.domain.property.dto.response.PropertySummaryCardResponse;
+import com.imjang.domain.property.service.PropertyMapService;
+import com.imjang.global.annotation.LoginRequired;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Property Map", description = "매물 지도 관련 API")
+@RestController
+@RequestMapping("/api/v1/properties")
+@RequiredArgsConstructor
+public class PropertyMapController {
+
+  private final PropertyMapService propertyMapService;
+
+  @Operation(summary = "지도 범위 내 마커 매물 조회",
+          description = "현재 보이는 지도 영역(viewport) 내의 매물 위치 정보를 조회")
+  @GetMapping("/map/markers")
+  @LoginRequired
+  public ResponseEntity<MapMarkersResponse> getMapMarkers(
+          @Valid @ModelAttribute MapBoundsRequest request,
+          HttpServletRequest servletRequest) {
+
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
+    MapMarkersResponse response = propertyMapService.getMapMarkers(request, userSession.userId());
+
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(summary = "매물 간략 정보 조회",
+          description = "지도에서 마커 선택 시 표시할 매물의 간략 정보를 조회")
+  @GetMapping("/{propertyId}/summary")
+  @LoginRequired
+  public ResponseEntity<PropertySummaryCardResponse> getPropertySummaryCard(
+          @Parameter(description = "매물 ID", required = true, example = "1")
+          @PathVariable Long propertyId,
+          HttpServletRequest servletRequest) {
+
+    UserSession userSession = (UserSession) servletRequest.getAttribute("USER_SESSION");
+    PropertySummaryCardResponse response = propertyMapService.getPropertySummaryCard(
+            propertyId,
+            userSession.userId()
+    );
+
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/imjang/domain/property/dto/request/MapBoundsRequest.java
+++ b/src/main/java/com/imjang/domain/property/dto/request/MapBoundsRequest.java
@@ -1,0 +1,41 @@
+package com.imjang.domain.property.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "지도 영역 조회 요청")
+public record MapBoundsRequest(
+        @Schema(description = "화면 우상단 위도", example = "37.5100")
+        @NotNull(message = "우상단 위도는 필수")
+        @Min(value = -90, message = "위도는 -90 이상이어야 합니다")
+        @Max(value = 90, message = "위도는 90 이하여야 합니다")
+        Double northEastLat,
+
+        @Schema(description = "화면 우상단 경도", example = "127.0500")
+        @NotNull(message = "우상단 경도는 필수")
+        @Min(value = -180, message = "경도는 -180 이상이어야 합니다")
+        @Max(value = 180, message = "경도는 180 이하여야 합니다")
+        Double northEastLng,
+
+        @Schema(description = "화면 좌하단 위도", example = "37.4900")
+        @NotNull(message = "좌하단 위도는 필수")
+        @Min(value = -90, message = "위도는 -90 이상이어야 합니다")
+        @Max(value = 90, message = "위도는 90 이하여야 합니다")
+        Double southWestLat,
+
+        @Schema(description = "화면 좌하단 경도", example = "127.0300")
+        @NotNull(message = "좌하단 경도는 필수")
+        @Min(value = -180, message = "경도는 -180 이상이어야 합니다")
+        @Max(value = 180, message = "경도는 180 이하여야 합니다")
+        Double southWestLng,
+
+        @Schema(description = "현재 지도 줌 레벨", example = "15")
+        @NotNull(message = "줌 레벨은 필수")
+        @Min(value = 1, message = "줌 레벨은 1 이상이어야 합니다")
+        @Max(value = 21, message = "줌 레벨은 21 이하여야 합니다")
+        Integer zoomLevel
+) {
+
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/MapMarkersResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/MapMarkersResponse.java
@@ -1,0 +1,15 @@
+package com.imjang.domain.property.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "지도 마커 목록 응답")
+public record MapMarkersResponse(
+        @Schema(description = "마커 정보 목록")
+        List<PropertyMarkerResponse> markers
+) {
+
+  public static MapMarkersResponse of(List<PropertyMarkerResponse> markers) {
+    return new MapMarkersResponse(markers);
+  }
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/PropertyMarkerResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/PropertyMarkerResponse.java
@@ -1,0 +1,44 @@
+package com.imjang.domain.property.dto.response;
+
+import com.imjang.domain.property.entity.MarkerColor;
+import com.imjang.domain.property.entity.Property;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "마커 매물 정보")
+public record PropertyMarkerResponse(
+        @Schema(description = "매물 ID", example = "1")
+        Long id,
+
+        @Schema(description = "위도", example = "37.5012")
+        Double latitude,
+
+        @Schema(description = "경도", example = "127.0396")
+        Double longitude,
+
+        @Schema(description = "마커 색상", example = "GREEN")
+        MarkerColor markerColor,
+
+        @Schema(description = "해당 위치의 매물 수", example = "1")
+        Integer count
+) {
+
+  public static PropertyMarkerResponse from(Property property) {
+    return new PropertyMarkerResponse(
+            property.getId(),
+            property.getLatitude(),
+            property.getLongitude(),
+            getMarkerColor(property.getRating()),
+            1
+    );
+  }
+
+  private static MarkerColor getMarkerColor(Integer rating) {
+    if (rating >= 4) {
+      return MarkerColor.GREEN;
+    } else if (rating == 3) {
+      return MarkerColor.YELLOW;
+    } else {
+      return MarkerColor.RED;
+    }
+  }
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/PropertySummaryCardResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/PropertySummaryCardResponse.java
@@ -1,0 +1,34 @@
+package com.imjang.domain.property.dto.response;
+
+import com.imjang.domain.property.entity.PropertyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "매물 간략 정보 카드")
+public record PropertySummaryCardResponse(
+        @Schema(description = "매물 ID", example = "1")
+        Long id,
+
+        @Schema(description = "주소", example = "서초구 서초동 789-12")
+        String address,
+
+        @Schema(description = "가격 유형", example = "JEONSE")
+        PropertyType priceType,
+
+        @Schema(description = "보증금", example = "280000000")
+        Long deposit,
+
+        @Schema(description = "월세", example = "0")
+        Long monthlyRent,
+
+        @Schema(description = "평점", example = "4.0")
+        Double rating,
+
+        @Schema(description = "썸네일 이미지 URL", example = "/temp-images/2024/12/15/thumb_abc123.jpg")
+        String thumbnailUrl,
+
+        @Schema(description = "방문일시", example = "2024-12-15T14:30:00")
+        LocalDateTime visitedAt
+) {
+
+}

--- a/src/main/java/com/imjang/domain/property/entity/MarkerColor.java
+++ b/src/main/java/com/imjang/domain/property/entity/MarkerColor.java
@@ -1,0 +1,14 @@
+package com.imjang.domain.property.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MarkerColor {
+  GREEN("만족"),
+  YELLOW("보통"),
+  RED("불만족");
+
+  private final String description;
+}

--- a/src/main/java/com/imjang/domain/property/location/util/H3Util.java
+++ b/src/main/java/com/imjang/domain/property/location/util/H3Util.java
@@ -3,6 +3,8 @@ package com.imjang.domain.property.location.util;
 import com.uber.h3core.H3Core;
 import com.uber.h3core.util.LatLng;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -29,5 +31,38 @@ public class H3Util {
    */
   public LatLng getH3Center(String h3Index) {
     return h3Core.cellToLatLng(h3Index);
+  }
+
+  /**
+   * 지도 영역(viewport)에 포함되는 H3 인덱스 집합 반환
+   */
+  public Set<String> getH3IndicesForBounds(Double northEastLat, Double northEastLng,
+                                           Double southWestLat, Double southWestLng,
+                                           int resolution) {
+    try {
+      // viewport를 polygon으로 변환 (시계방향)
+      List<LatLng> boundary = List.of(
+              new LatLng(southWestLat, southWestLng),
+              new LatLng(northEastLat, southWestLng),
+              new LatLng(northEastLat, northEastLng),
+              new LatLng(southWestLat, northEastLng),
+              new LatLng(southWestLat, southWestLng)
+      );
+
+      List<Long> h3IndicesLong = h3Core.polygonToCells(boundary, null, resolution);
+
+      Set<String> h3Indices = h3IndicesLong.stream()
+              .map(h3Core::h3ToString)
+              .collect(java.util.stream.Collectors.toSet());
+
+      log.debug("Viewport H3 변환: resolution={}, count={}", resolution, h3Indices.size());
+
+      return h3Indices;
+
+    } catch (Exception e) {
+      log.error("H3 인덱스 집합 생성 실패: bounds=({},{}) to ({},{})",
+              southWestLat, southWestLng, northEastLat, northEastLng, e);
+      throw new RuntimeException("지도 영역 처리 중 오류가 발생했습니다.", e);
+    }
   }
 }

--- a/src/main/java/com/imjang/domain/property/repository/PropertyRepository.java
+++ b/src/main/java/com/imjang/domain/property/repository/PropertyRepository.java
@@ -2,7 +2,9 @@ package com.imjang.domain.property.repository;
 
 import com.imjang.domain.property.entity.Property;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +16,9 @@ public interface PropertyRepository extends JpaRepository<Property, Long> {
   @Query("SELECT p FROM Property p LEFT JOIN FETCH p.environments WHERE p.id = :id")
   Optional<Property> findByIdWithEnvironments(@Param("id") Long id);
 
+  // 삭제되지 않은 매물만 조회
+  Optional<Property> findByIdAndDeletedAtIsNull(Long id);
+
   // 최근 매물 조회
   Page<Property> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
@@ -24,4 +29,7 @@ public interface PropertyRepository extends JpaRepository<Property, Long> {
   long countByUserIdAndDeletedAtIsNullAndCreatedAtBetween(Long userId,
                                                           LocalDateTime startOfMonth,
                                                           LocalDateTime endOfMonth);
+
+  // H3 인덱스 기반 매물 조회 (삭제되지 않은 것만)
+  List<Property> findByUserIdAndH3IndexInAndDeletedAtIsNull(Long userId, Set<String> h3Indices);
 }

--- a/src/main/java/com/imjang/domain/property/service/PropertyMapService.java
+++ b/src/main/java/com/imjang/domain/property/service/PropertyMapService.java
@@ -1,0 +1,95 @@
+package com.imjang.domain.property.service;
+
+import com.imjang.domain.property.dto.request.MapBoundsRequest;
+import com.imjang.domain.property.dto.response.MapMarkersResponse;
+import com.imjang.domain.property.dto.response.PropertyMarkerResponse;
+import com.imjang.domain.property.dto.response.PropertySummaryCardResponse;
+import com.imjang.domain.property.entity.Property;
+import com.imjang.domain.property.entity.PropertyImage;
+import com.imjang.domain.property.location.util.H3Util;
+import com.imjang.domain.property.repository.PropertyImageRepository;
+import com.imjang.domain.property.repository.PropertyRepository;
+import com.imjang.global.exception.CustomException;
+import com.imjang.global.exception.ErrorCode;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PropertyMapService {
+
+  private final PropertyRepository propertyRepository;
+  private final PropertyImageRepository propertyImageRepository;
+  private final H3Util h3Util;
+
+  /**
+   * 지도 영역 내 매물 마커 조회
+   */
+  @Transactional(readOnly = true)
+  public MapMarkersResponse getMapMarkers(MapBoundsRequest request, Long userId) {
+    Set<String> h3Indices = h3Util.getH3IndicesForBounds(
+            request.northEastLat(),
+            request.northEastLng(),
+            request.southWestLat(),
+            request.southWestLng(),
+            getH3Resolution(request.zoomLevel())
+    );
+
+    List<Property> properties = propertyRepository.findByUserIdAndH3IndexInAndDeletedAtIsNull(userId, h3Indices);
+
+    List<PropertyMarkerResponse> markers = properties.stream()
+            .map(PropertyMarkerResponse::from)
+            .toList();
+
+    return MapMarkersResponse.of(markers);
+  }
+
+  /**
+   * 매물 간략 정보 카드 조회
+   */
+  @Transactional(readOnly = true)
+  public PropertySummaryCardResponse getPropertySummaryCard(Long propertyId, Long userId) {
+    Property property = propertyRepository.findByIdAndDeletedAtIsNull(propertyId)
+            .orElseThrow(() -> new CustomException(ErrorCode.PROPERTY_NOT_FOUND));
+
+    if (!property.getUser().getId().equals(userId)) {
+      throw new CustomException(ErrorCode.ACCESS_DENIED);
+    }
+
+    String thumbnailUrl = propertyImageRepository
+            .findByPropertyIdAndDisplayOrder(propertyId, 0)
+            .map(PropertyImage::getThumbnailUrl)
+            .orElse(null);
+
+    return new PropertySummaryCardResponse(
+            property.getId(),
+            property.getAddress(),
+            property.getPriceType(),
+            property.getDeposit(),
+            property.getMonthlyRent(),
+            property.getRating().doubleValue(),
+            thumbnailUrl,
+            property.getCreatedAt()
+    );
+  }
+
+  /**
+   * 줌 레벨에 따른 H3 해상도 결정
+   */
+  private int getH3Resolution(Integer zoomLevel) {
+    if (zoomLevel >= 18) {
+      return 11;  // 매우 상세
+    } else if (zoomLevel >= 16) {
+      return 10;
+    } else if (zoomLevel >= 14) {
+      return 9;   // 기본값
+    } else {
+      return 8;    // 광역
+    }
+  }
+}

--- a/src/main/java/com/imjang/global/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/imjang/global/interceptor/AuthInterceptor.java
@@ -47,6 +47,9 @@ public class AuthInterceptor implements HandlerInterceptor {
       throw new CustomException(ErrorCode.UNAUTHORIZED);
     }
 
+    // 검증된 사용자 세션을 request attribute에 저장
+    request.setAttribute("USER_SESSION", userSession);
+
     log.debug("🔓인증된 사용자 정보: {}", userSession.email());
 
     return true;

--- a/src/test/java/com/imjang/domain/property/service/PropertyMapServiceTest.java
+++ b/src/test/java/com/imjang/domain/property/service/PropertyMapServiceTest.java
@@ -1,0 +1,309 @@
+package com.imjang.domain.property.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.imjang.domain.auth.entity.User;
+import com.imjang.domain.property.dto.request.MapBoundsRequest;
+import com.imjang.domain.property.dto.response.MapMarkersResponse;
+import com.imjang.domain.property.dto.response.PropertySummaryCardResponse;
+import com.imjang.domain.property.entity.Property;
+import com.imjang.domain.property.entity.PropertyImage;
+import com.imjang.domain.property.entity.PropertyType;
+import com.imjang.domain.property.location.util.H3Util;
+import com.imjang.domain.property.repository.PropertyImageRepository;
+import com.imjang.domain.property.repository.PropertyRepository;
+import com.imjang.global.exception.CustomException;
+import com.imjang.global.exception.ErrorCode;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PropertyMapServiceTest {
+
+  @InjectMocks
+  private PropertyMapService propertyMapService;
+
+  @Mock
+  private PropertyRepository propertyRepository;
+
+  @Mock
+  private PropertyImageRepository propertyImageRepository;
+
+  @Mock
+  private H3Util h3Util;
+
+  @Test
+  @DisplayName("지도 마커 조회 - 정상 케이스")
+  void getMapMarkers_Success() {
+    // Given
+    MapBoundsRequest request = new MapBoundsRequest(
+            37.5100, 127.0500, 37.4900, 127.0300, 15
+    );
+    Long userId = 1L;
+    Set<String> h3Indices = Set.of("891f0d92b93ffff");
+
+    Property property = mock(Property.class);
+    when(property.getId()).thenReturn(1L);
+    when(property.getLatitude()).thenReturn(37.5012);
+    when(property.getLongitude()).thenReturn(127.0396);
+    when(property.getRating()).thenReturn(4);
+
+    List<Property> properties = List.of(property);
+
+    given(h3Util.getH3IndicesForBounds(
+            request.northEastLat(), request.northEastLng(),
+            request.southWestLat(), request.southWestLng(), 9)
+    ).willReturn(h3Indices);
+
+    given(propertyRepository.findByUserIdAndH3IndexInAndDeletedAtIsNull(userId, h3Indices))
+            .willReturn(properties);
+
+    // When
+    MapMarkersResponse response = propertyMapService.getMapMarkers(request, userId);
+
+    // Then
+    assertThat(response.markers()).hasSize(1);
+    assertThat(response.markers().get(0).id()).isEqualTo(1L);
+    assertThat(response.markers().get(0).latitude()).isEqualTo(37.5012);
+    assertThat(response.markers().get(0).longitude()).isEqualTo(127.0396);
+
+    verify(h3Util).getH3IndicesForBounds(
+            request.northEastLat(), request.northEastLng(),
+            request.southWestLat(), request.southWestLng(), 9);
+    verify(propertyRepository).findByUserIdAndH3IndexInAndDeletedAtIsNull(userId, h3Indices);
+  }
+
+  @Test
+  @DisplayName("지도 마커 조회 - 빈 결과")
+  void getMapMarkers_EmptyResult() {
+    // Given
+    MapBoundsRequest request = new MapBoundsRequest(
+            37.5100, 127.0500, 37.4900, 127.0300, 15
+    );
+    Long userId = 1L;
+    Set<String> h3Indices = Set.of("891f0d92b93ffff");
+
+    given(h3Util.getH3IndicesForBounds(
+            request.northEastLat(), request.northEastLng(),
+            request.southWestLat(), request.southWestLng(), 9))
+            .willReturn(h3Indices);
+    given(propertyRepository.findByUserIdAndH3IndexInAndDeletedAtIsNull(userId, h3Indices))
+            .willReturn(Collections.emptyList());
+
+    // When
+    MapMarkersResponse response = propertyMapService.getMapMarkers(request, userId);
+
+    // Then
+    assertThat(response.markers()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("매물 간략 정보 조회")
+  void getPropertySummaryCard_Success_WithThumbnail() {
+    // Given
+    Long propertyId = 1L;
+    Long userId = 1L;
+
+    User user = createTestUser(userId);
+    Property property = createTestProperty(propertyId, user);
+    PropertyImage propertyImage = createTestPropertyImage(propertyId);
+
+    given(propertyRepository.findByIdAndDeletedAtIsNull(propertyId))
+            .willReturn(Optional.of(property));
+    given(propertyImageRepository.findByPropertyIdAndDisplayOrder(propertyId, 0))
+            .willReturn(Optional.of(propertyImage));
+
+    // When
+    PropertySummaryCardResponse response = propertyMapService.getPropertySummaryCard(propertyId, userId);
+
+    // Then
+    assertThat(response.id()).isEqualTo(propertyId);
+    assertThat(response.address()).isEqualTo("서초구 서초동 789-12");
+    assertThat(response.priceType()).isEqualTo(PropertyType.JEONSE);
+    assertThat(response.deposit()).isEqualTo(280000000L);
+    assertThat(response.monthlyRent()).isEqualTo(0L);
+    assertThat(response.rating()).isEqualTo(4.0);
+    assertThat(response.thumbnailUrl()).isEqualTo("thumbnail.jpg");
+    assertThat(response.visitedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("매물 간략 정보 조회 - 정상 케이")
+  void getPropertySummaryCard_Success_WithoutThumbnail() {
+    // Given
+    Long propertyId = 1L;
+    Long userId = 1L;
+
+    User user = createTestUser(userId);
+    Property property = createTestProperty(propertyId, user);
+
+    given(propertyRepository.findByIdAndDeletedAtIsNull(propertyId))
+            .willReturn(Optional.of(property));
+    given(propertyImageRepository.findByPropertyIdAndDisplayOrder(propertyId, 0))
+            .willReturn(Optional.empty());
+
+    // When
+    PropertySummaryCardResponse response = propertyMapService.getPropertySummaryCard(propertyId, userId);
+
+    // Then
+    assertThat(response.thumbnailUrl()).isNull();
+  }
+
+  @Test
+  @DisplayName("매물 간략 정보 조회 - 매물 없음 예외")
+  void getPropertySummaryCard_PropertyNotFound() {
+    // Given
+    Long propertyId = 999L;
+    Long userId = 1L;
+
+    given(propertyRepository.findByIdAndDeletedAtIsNull(propertyId))
+            .willReturn(Optional.empty());
+
+    // When & Then
+    assertThatThrownBy(() -> propertyMapService.getPropertySummaryCard(propertyId, userId))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PROPERTY_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("매물 간략 정보 조회 - 권한 없음 예외")
+  void getPropertySummaryCard_AccessDenied() {
+    // Given
+    Long propertyId = 1L;
+    Long userId = 1L;
+    Long otherUserId = 2L;
+
+    User otherUser = createTestUser(otherUserId);
+    Property property = createTestProperty(propertyId, otherUser);
+
+    given(propertyRepository.findByIdAndDeletedAtIsNull(propertyId))
+            .willReturn(Optional.of(property));
+
+    // When & Then
+    assertThatThrownBy(() -> propertyMapService.getPropertySummaryCard(propertyId, userId))
+            .isInstanceOf(CustomException.class)
+            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+  }
+
+  @Test
+  @DisplayName("H3 해상도 결정 - 줌 레벨 18 이상")
+  void getH3Resolution_ZoomLevel18OrHigher() throws Exception {
+    // Given
+    Integer zoomLevel = 18;
+
+    // When
+    int resolution = invokeGetH3Resolution(zoomLevel);
+
+    // Then
+    assertThat(resolution).isEqualTo(11);
+  }
+
+  @Test
+  @DisplayName("H3 해상도 결정 - 줌 레벨 16-17")
+  void getH3Resolution_ZoomLevel16To17() throws Exception {
+    // Given
+    Integer zoomLevel = 16;
+
+    // When
+    int resolution = invokeGetH3Resolution(zoomLevel);
+
+    // Then
+    assertThat(resolution).isEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("H3 해상도 결정 - 줌 레벨 14-15")
+  void getH3Resolution_ZoomLevel14To15() throws Exception {
+    // Given
+    Integer zoomLevel = 14;
+
+    // When
+    int resolution = invokeGetH3Resolution(zoomLevel);
+
+    // Then
+    assertThat(resolution).isEqualTo(9);
+  }
+
+  @Test
+  @DisplayName("H3 해상도 결정 - 줌 레벨 13 이하")
+  void getH3Resolution_ZoomLevel13OrLower() throws Exception {
+    // Given
+    Integer zoomLevel = 13;
+
+    // When
+    int resolution = invokeGetH3Resolution(zoomLevel);
+
+    // Then
+    assertThat(resolution).isEqualTo(8);
+  }
+
+  @Test
+  @DisplayName("H3 해상도 결정 - 경계값 테스트")
+  void getH3Resolution_BoundaryValues() throws Exception {
+    // Given & When & Then
+    assertThat(invokeGetH3Resolution(18)).isEqualTo(11);
+    assertThat(invokeGetH3Resolution(17)).isEqualTo(10);
+    assertThat(invokeGetH3Resolution(16)).isEqualTo(10);
+    assertThat(invokeGetH3Resolution(15)).isEqualTo(9);
+    assertThat(invokeGetH3Resolution(14)).isEqualTo(9);
+    assertThat(invokeGetH3Resolution(13)).isEqualTo(8);
+    assertThat(invokeGetH3Resolution(1)).isEqualTo(8);
+  }
+
+  private User createTestUser(Long userId) {
+    User user = mock(User.class, withSettings().lenient());
+    lenient().when(user.getId()).thenReturn(userId);
+    return user;
+  }
+
+  private Property createTestProperty(Long propertyId, User user) {
+    Property property = mock(Property.class, withSettings().lenient());
+
+    // Mock 설정
+    lenient().when(property.getId()).thenReturn(propertyId);
+    lenient().when(property.getUser()).thenReturn(user);
+    lenient().when(property.getAddress()).thenReturn("서초구 서초동 789-12");
+    lenient().when(property.getLatitude()).thenReturn(37.5012);
+    lenient().when(property.getLongitude()).thenReturn(127.0396);
+    lenient().when(property.getPriceType()).thenReturn(PropertyType.JEONSE);
+    lenient().when(property.getDeposit()).thenReturn(280000000L);
+    lenient().when(property.getMonthlyRent()).thenReturn(0L);
+    lenient().when(property.getRating()).thenReturn(4);
+    lenient().when(property.getCreatedAt()).thenReturn(java.time.LocalDateTime.now());
+
+    return property;
+  }
+
+  private PropertyImage createTestPropertyImage(Long propertyId) {
+    Property mockProperty = mock(Property.class, withSettings().lenient());
+    lenient().when(mockProperty.getId()).thenReturn(propertyId);
+
+    PropertyImage propertyImage = mock(PropertyImage.class, withSettings().lenient());
+    lenient().when(propertyImage.getThumbnailUrl()).thenReturn("thumbnail.jpg");
+    lenient().when(propertyImage.getProperty()).thenReturn(mockProperty);
+
+    return propertyImage;
+  }
+
+  private int invokeGetH3Resolution(Integer zoomLevel) throws Exception {
+    Method method = PropertyMapService.class.getDeclaredMethod("getH3Resolution", Integer.class);
+    method.setAccessible(true);
+    return (int) method.invoke(propertyMapService, zoomLevel);
+  }
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

- 지도 뷰에서 매물 위치를 효율적으로 표시하기 위한 API 개발
- H3 지리공간 인덱싱을 활용하여 대용량 매물 데이터를 빠르게 조회
- 인증 로직을 HttpServletRequest 기반으로 개선하여 더 안전하고 일관된 처리

## 🛠 주요 변경 사항

1. [기능] 지도 마커 및 매물 요약 정보 API 추가 (`PropertyMapController`, `PropertyMapService` 신규 생성)
2. [기능] H3 인덱싱 기반 지도 영역 계산 로직 추가 (`H3Util.getH3IndicesForBounds()` 메서드 추가)
3. [수정] 인증 처리 방식 개선 - `AuthInterceptor`에서 UserSession을 HttpServletRequest attribute로 설정
4. [수정] 모든 Controller의 인증 로직을 HttpSession 대신 HttpServletRequest 사용으로 통일
5. [테스트] `PropertyMapService` 단위 테스트 작성 (마커 조회, 요약 카드, H3 해상도 결정 로직 검증)

## 📋 작업 상세 내용

### 데이터베이스 변경
- 변경 사항 없음 (기존 Property 엔티티의 h3Index 필드 활용)

### 새로운 의존성
- 추가된 의존성 없음 (기존 H3 라이브러리 활용)

### API 엔드포인트 추가
- `GET /api/v1/properties/map/markers` - 지도 범위 내 매물 마커 조회
- `GET /api/v1/properties/{propertyId}/summary` - 매물 간략 정보 카드 조회

### 성능 최적화
- H3 지리공간 인덱싱을 활용하여 지도 뷰포트 내 매물만 효율적으로 조회
- 줌 레벨에 따른 동적 H3 해상도 조정으로 성능 최적화

### 보안 개선
- AuthInterceptor에서 검증된 UserSession을 request attribute로 설정
- 모든 Controller에서 일관된 방식으로 사용자 인증 정보 접근

## 📐 테스트 결과 및 검증

- 유닛 테스트 결과: PropertyMapServiceTest 전체 통과
  - 지도 마커 조회 정상/빈 결과 케이스
  - 매물 요약 정보 조회 (썸네일 있음/없음)
  - 권한 검증 (타 사용자 매물 접근 차단)
  - H3 해상도 결정 로직 경계값 테스트
- 통합 테스트: 실제 지도 뷰포트 데이터로 API 호출 테스트 완료
