### PR TITLE
매물 타임라인 조회 API 기능 추가

### DIFF
--- a/src/main/java/com/imjang/domain/property/dto/response/PropertyTimelineResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/PropertyTimelineResponse.java
@@ -1,0 +1,21 @@
+package com.imjang.domain.property.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "매물 타임라인 응답")
+public record PropertyTimelineResponse(
+        @Schema(description = "응답 코드", example = "200")
+        int code,
+
+        @Schema(description = "타임라인 데이터")
+        List<TimelineGroupResponse> data,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext
+) {
+
+  public static PropertyTimelineResponse of(List<TimelineGroupResponse> data, boolean hasNext) {
+    return new PropertyTimelineResponse(200, data, hasNext);
+  }
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/TimelineGroupResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/TimelineGroupResponse.java
@@ -1,0 +1,15 @@
+package com.imjang.domain.property.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+@Schema(description = "날짜별 그룹화된 매물 정보")
+public record TimelineGroupResponse(
+        @Schema(description = "날짜", example = "2024-12-28")
+        LocalDate date,
+
+        @Schema(description = "해당 날짜의 매물 목록")
+        List<TimelinePropertyResponse> properties
+) {
+}

--- a/src/main/java/com/imjang/domain/property/dto/response/TimelinePropertyResponse.java
+++ b/src/main/java/com/imjang/domain/property/dto/response/TimelinePropertyResponse.java
@@ -1,0 +1,42 @@
+package com.imjang.domain.property.dto.response;
+
+import com.imjang.domain.property.entity.PropertyType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "타임라인 매물 정보")
+public record TimelinePropertyResponse(
+        @Schema(description = "매물 ID", example = "123")
+        Long id,
+
+        @Schema(description = "방문 일시", example = "2024-12-28T10:30:00")
+        LocalDateTime visitedAt,
+
+        @Schema(description = "주소", example = "강남구 역삼동")
+        String address,
+
+        @Schema(description = "평점", example = "4")
+        Integer rating,
+
+        @Schema(description = "가격 유형", example = "JEONSE")
+        PropertyType priceType,
+
+        @Schema(description = "보증금", example = "350000000")
+        Long deposit,
+
+        @Schema(description = "월세", example = "0")
+        Long monthlyRent,
+
+        @Schema(description = "면적(제곱미터)", example = "82.64")
+        Integer area,
+
+        @Schema(description = "층수", example = "5")
+        Integer floor,
+
+        @Schema(description = "총 층수", example = "15")
+        Integer totalFloor,
+
+        @Schema(description = "썸네일 URL", example = "/api/v1/properties/123/thumbnail")
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/imjang/domain/property/repository/PropertyRepository.java
+++ b/src/main/java/com/imjang/domain/property/repository/PropertyRepository.java
@@ -19,7 +19,7 @@ public interface PropertyRepository extends JpaRepository<Property, Long> {
   // 삭제되지 않은 매물만 조회
   Optional<Property> findByIdAndDeletedAtIsNull(Long id);
 
-  // 최근 매물 조회
+  // 최근 매물 조회 & 타임라인 매물 조회
   Page<Property> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
   // 전체 매물 개수 조회


### PR DESCRIPTION
## 📌 변경 사항 개요

- 사용자별 매물을 날짜별로 그룹화하여 타임라인 형태로 조회하는 API
- 페이징 기능을 지원하여 대량의 매물 데이터 처리 가능

## 🛠 주요 변경 사항

1. [기능] 매물 타임라인 조회 API 추가 (`PropertyController`에 `/properties/timeline` 엔드포인트 추가)
2. [기능] 타임라인 응답 DTO 클래스 생성 (`PropertyTimelineResponse`, `TimelineGroupResponse`, `TimelinePropertyResponse`)
3. [기능] 타임라인 조회 서비스 로직 구현 (`PropertyService`에 `getPropertyTimeline` 메서드 추가)

## 📋 작업 상세 내용

- 기존 데이터베이스 스키마 변경 없이 기존 테이블과 쿼리를 활용하여 구현
- 사용자별 매물을 생성일 기준 내림차순으로 조회
- 날짜별로 그룹화하여 타임라인 형태로 반환
- 페이징 처리로 대량 데이터 효율적 처리
- 각 매물의 썸네일 이미지 URL 포함
