### PR TITLE
fix: H3 해상도 불일치로 인한 지도 마커 빈 응답 수정

### DIFF
--- a/src/main/java/com/imjang/domain/property/service/PropertyMapService.java
+++ b/src/main/java/com/imjang/domain/property/service/PropertyMapService.java
@@ -41,7 +41,7 @@ public class PropertyMapService {
               request.northEastLng(),
               request.southWestLat(),
               request.southWestLng(),
-              getH3Resolution(request.zoomLevel())
+              9  // 매물 저장 해상도와 동일하게 고정
       );
     } catch (Exception e) {
       log.warn("H3 변환 실패, 빈 마커 반환", e);
@@ -106,18 +106,4 @@ public class PropertyMapService {
     );
   }
 
-  /**
-   * 줌 레벨에 따른 H3 해상도 결정
-   */
-  private int getH3Resolution(Integer zoomLevel) {
-    if (zoomLevel >= 18) {
-      return 11;  // 매우 상세
-    } else if (zoomLevel >= 16) {
-      return 10;
-    } else if (zoomLevel >= 14) {
-      return 9;   // 기본값
-    } else {
-      return 8;    // 광역
-    }
-  }
 }

--- a/src/test/java/com/imjang/domain/property/service/PropertyMapServiceTest.java
+++ b/src/test/java/com/imjang/domain/property/service/PropertyMapServiceTest.java
@@ -21,7 +21,6 @@ import com.imjang.domain.property.repository.PropertyImageRepository;
 import com.imjang.domain.property.repository.PropertyRepository;
 import com.imjang.global.exception.CustomException;
 import com.imjang.global.exception.ErrorCode;
-import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -272,71 +271,6 @@ class PropertyMapServiceTest {
             .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
   }
 
-  @Test
-  @DisplayName("H3 해상도 결정 - 줌 레벨 18 이상")
-  void getH3Resolution_ZoomLevel18OrHigher() throws Exception {
-    // Given
-    Integer zoomLevel = 18;
-
-    // When
-    int resolution = invokeGetH3Resolution(zoomLevel);
-
-    // Then
-    assertThat(resolution).isEqualTo(11);
-  }
-
-  @Test
-  @DisplayName("H3 해상도 결정 - 줌 레벨 16-17")
-  void getH3Resolution_ZoomLevel16To17() throws Exception {
-    // Given
-    Integer zoomLevel = 16;
-
-    // When
-    int resolution = invokeGetH3Resolution(zoomLevel);
-
-    // Then
-    assertThat(resolution).isEqualTo(10);
-  }
-
-  @Test
-  @DisplayName("H3 해상도 결정 - 줌 레벨 14-15")
-  void getH3Resolution_ZoomLevel14To15() throws Exception {
-    // Given
-    Integer zoomLevel = 14;
-
-    // When
-    int resolution = invokeGetH3Resolution(zoomLevel);
-
-    // Then
-    assertThat(resolution).isEqualTo(9);
-  }
-
-  @Test
-  @DisplayName("H3 해상도 결정 - 줌 레벨 13 이하")
-  void getH3Resolution_ZoomLevel13OrLower() throws Exception {
-    // Given
-    Integer zoomLevel = 13;
-
-    // When
-    int resolution = invokeGetH3Resolution(zoomLevel);
-
-    // Then
-    assertThat(resolution).isEqualTo(8);
-  }
-
-  @Test
-  @DisplayName("H3 해상도 결정 - 경계값 테스트")
-  void getH3Resolution_BoundaryValues() throws Exception {
-    // Given & When & Then
-    assertThat(invokeGetH3Resolution(18)).isEqualTo(11);
-    assertThat(invokeGetH3Resolution(17)).isEqualTo(10);
-    assertThat(invokeGetH3Resolution(16)).isEqualTo(10);
-    assertThat(invokeGetH3Resolution(15)).isEqualTo(9);
-    assertThat(invokeGetH3Resolution(14)).isEqualTo(9);
-    assertThat(invokeGetH3Resolution(13)).isEqualTo(8);
-    assertThat(invokeGetH3Resolution(1)).isEqualTo(8);
-  }
-
   private User createTestUser(Long userId) {
     User user = mock(User.class, withSettings().lenient());
     lenient().when(user.getId()).thenReturn(userId);
@@ -372,9 +306,4 @@ class PropertyMapServiceTest {
     return propertyImage;
   }
 
-  private int invokeGetH3Resolution(Integer zoomLevel) throws Exception {
-    Method method = PropertyMapService.class.getDeclaredMethod("getH3Resolution", Integer.class);
-    method.setAccessible(true);
-    return (int) method.invoke(propertyMapService, zoomLevel);
-  }
 }


### PR DESCRIPTION
매물은 resolution 9로 저장되는데 getH3Resolution()이 zoomLevel 5에서 resolution 8을 반환해 항상 빈 결과가 반환되는 버그 수정.
viewport 쿼리 해상도를 저장 해상도(9)와 동일하게 고정, getH3Resolution() 제거.

## Summary by Sourcery

저장된 속성의 해상도와 H3 쿼리 해상도를 일치시켜 지도 마커 조회 문제를 수정합니다.

버그 수정:
- 저장된 속성과 동일한 H3 해상도를 사용하여, 모든 줌 레벨에서 지도 마커가 올바르게 반환되도록 보장합니다.

개선 사항:
- 줌 레벨 기반 H3 해상도 로직을 제거하여 지도 해상도 처리를 단순화합니다.

테스트:
- 제거된 줌 레벨 기반 H3 해상도 계산을 검증하던 더 이상 필요 없는 테스트들을 삭제합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix map marker retrieval by aligning H3 query resolution with the stored property resolution.

Bug Fixes:
- Ensure map markers are returned correctly at all zoom levels by using the same H3 resolution as the stored properties.

Enhancements:
- Simplify map resolution handling by removing zoom-level-based H3 resolution logic.

Tests:
- Remove obsolete tests that validated the removed zoom-level-based H3 resolution calculation.

</details>